### PR TITLE
Add Word Grid Challenge game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Word Grid Challenge</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="controls">
+    <div class="scores">
+      <div>Score: <span id="score">0</span></div>
+      <div>High Score: <span id="high-score">0</span></div>
+      <div>Time: <span id="timer">60</span>s</div>
+    </div>
+    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+  </header>
+  <main>
+    <div id="grid" class="grid"></div>
+    <input id="word-input" type="text" placeholder="Type a word" autocomplete="off" />
+    <ul id="word-list"></ul>
+    <button id="restart">Restart</button>
+  </main>
+  <audio id="success-sound" src="data:audio/wav;base64,UklGRrQBAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YZABAAB/z/vurVcTASh3yfrxtV8YACJvw/f1vGcdAB1nvPX3w28iABhftfH6yXcoARNXre77z34uAg9Qpur81YY0AwxInuX92446BghBluD+4JZBCAY6jtv95Z5IDAM0htX86qZQDwIuf8/77q1XEwEod8n68bVfGAAib8P39bxnHQAdZ7z198NvIgAYX7Xx+sl3KAETV63u+89/LgIPUKbq/NWGNAMMSJ7l/duOOgYIQZbg/uCWQQgGOo7b/eWeSAwDNIbV/OqmUA8CLn/P++6tVxMBKHfJ+vG1XxgAIm/D9/W8Zx0AHWe89ffDbyIAGF+18frJdygBE1et7vvPfi4CD1Cm6vzVhjQDDEie5f3bjjoGCEGW4P7glkEIBjqO2/3lnkgMAzSG1fzqplAPAi5+z/vurVcTASh3yfrxtV8YACJvw/f1vGcdAB1nvPX3w28iABhftfH6yXcoARNXre77z34uAg9Qpur81YY0AwxInuX92446BghBluD+4JZBCAY6jtv95Z5IDAM0htX86qZQDwIu" preload="auto"></audio>
+  <audio id="fail-sound" src="data:audio/wav;base64,UklGRrQBAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YZABAAB/kqa4ydjl8Pf8/vz38OXYybimkn5rV0U0JRgNBgEAAQYNGCU0RVdrf5KmuMnY5fD3/P789/Dl2Mm4ppJ/a1dFNCUYDQYBAAEGDRglNEVXa3+SprjJ2OXw9/z+/Pfw5djJuKaSf2tXRTQlGA0GAQABBg0YJTRFV2t+kqa4ydjl8Pf8/vz38OXYybimkn5rV0U0JRgNBgEAAQYNGCU0RVdrf5KmuMnY5fD3/P789/Dl2Mm4ppJ/a1dFNCUYDQYBAAEGDRglNEVXa36SprjJ2OXw9/z+/Pfw5djJuKaSfmtXRTQlGA0GAQABBg0YJTRFV2t+kqa4ydjl8Pf8/vz38OXYybimkn5rV0U0JRgNBgEAAQYNGCU0RVdrf5KmuMnY5fD3/P789/Dl2Mm4ppJ+a1dFNCUYDQYBAAEGDRglNEVXa3+SprjJ2OXw9/z+/Pfw5djJuKaSf2tXRTQlGA0GAQABBg0YJTRFV2t+kqa4ydjl8Pf8/vz38OXYybimkn5rV0U0JRgNBgEAAQYNGCU0RVdr" preload="auto"></audio>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,117 @@
+const gridEl = document.getElementById('grid');
+const inputEl = document.getElementById('word-input');
+const scoreEl = document.getElementById('score');
+const highScoreEl = document.getElementById('high-score');
+const timerEl = document.getElementById('timer');
+const wordListEl = document.getElementById('word-list');
+const restartBtn = document.getElementById('restart');
+const themeToggle = document.getElementById('theme-toggle');
+const successSound = document.getElementById('success-sound');
+const failSound = document.getElementById('fail-sound');
+
+let gridLetters = [];
+let usedWords = new Set();
+let score = 0;
+let timeLeft = 60;
+let timerId = null;
+let highScore = parseInt(localStorage.getItem('highScore')) || 0;
+highScoreEl.textContent = highScore;
+
+function generateGrid() {
+  gridEl.innerHTML = '';
+  gridLetters = [];
+  for (let i = 0; i < 16; i++) {
+    const letter = String.fromCharCode(65 + Math.floor(Math.random() * 26));
+    gridLetters.push(letter);
+    const tile = document.createElement('div');
+    tile.className = 'tile';
+    tile.textContent = letter;
+    gridEl.appendChild(tile);
+  }
+}
+
+function startGame() {
+  score = 0;
+  usedWords.clear();
+  wordListEl.innerHTML = '';
+  scoreEl.textContent = score;
+  inputEl.value = '';
+  inputEl.disabled = false;
+  timeLeft = 60;
+  timerEl.textContent = timeLeft;
+  if (timerId) clearInterval(timerId);
+  timerId = setInterval(() => {
+    timeLeft--;
+    timerEl.textContent = timeLeft;
+    if (timeLeft <= 0) {
+      endGame();
+    }
+  }, 1000);
+  generateGrid();
+  inputEl.focus();
+}
+
+function endGame() {
+  clearInterval(timerId);
+  inputEl.disabled = true;
+  const words = Array.from(usedWords);
+  alert(`Time's up!\nScore: ${score}\nWords: ${words.join(', ')}`);
+  if (score > highScore) {
+    highScore = score;
+    localStorage.setItem('highScore', highScore);
+    highScoreEl.textContent = highScore;
+  }
+}
+
+function validateWord(word) {
+  if (word.length < 3) return false;
+  if (usedWords.has(word)) return false;
+  const gridCounts = {};
+  gridLetters.forEach(l => (gridCounts[l] = (gridCounts[l] || 0) + 1));
+  const wordCounts = {};
+  for (const char of word) {
+    if (!gridCounts[char]) return false;
+    wordCounts[char] = (wordCounts[char] || 0) + 1;
+    if (wordCounts[char] > gridCounts[char]) return false;
+  }
+  return true;
+}
+
+function handleInput(e) {
+  if (e.key === 'Enter') {
+    const word = inputEl.value.trim().toUpperCase();
+    if (validateWord(word)) {
+      usedWords.add(word);
+      score += word.length;
+      scoreEl.textContent = score;
+      const li = document.createElement('li');
+      li.textContent = word;
+      wordListEl.appendChild(li);
+      successSound.currentTime = 0;
+      successSound.play();
+    } else {
+      failSound.currentTime = 0;
+      failSound.play();
+    }
+    inputEl.value = '';
+  }
+}
+
+inputEl.addEventListener('keydown', handleInput);
+restartBtn.addEventListener('click', startGame);
+
+function applyTheme(theme) {
+  document.body.classList.toggle('dark', theme === 'dark');
+  themeToggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+}
+
+const savedTheme = localStorage.getItem('theme') || 'light';
+applyTheme(savedTheme);
+
+themeToggle.addEventListener('click', () => {
+  const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+  localStorage.setItem('theme', newTheme);
+  applyTheme(newTheme);
+});
+
+window.addEventListener('load', startGame);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,130 @@
+:root {
+  --bg-color: #f5f5f5;
+  --text-color: #333;
+  --tile-bg: #ffffff;
+  --tile-border: #cccccc;
+  --accent-color: #0077ff;
+}
+
+body.dark {
+  --bg-color: #1e1e1e;
+  --text-color: #e2e2e2;
+  --tile-bg: #333333;
+  --tile-border: #555555;
+}
+
+body {
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.controls {
+  width: 100%;
+  max-width: 500px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+}
+
+.scores {
+  display: flex;
+  gap: 1rem;
+}
+
+#theme-toggle {
+  background: var(--tile-bg);
+  border: 2px solid var(--tile-border);
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0.5rem;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 60px);
+  gap: 10px;
+  margin-top: 1rem;
+}
+
+.tile {
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  background: var(--tile-bg);
+  border: 2px solid var(--tile-border);
+  border-radius: 8px;
+  transition: transform 0.2s ease, background 0.3s ease;
+  user-select: none;
+}
+
+.tile:hover {
+  transform: scale(1.1) rotate(2deg);
+  background: var(--accent-color);
+  color: #fff;
+}
+
+#word-input {
+  margin-top: 1rem;
+  padding: 0.5rem;
+  font-size: 1rem;
+  text-transform: uppercase;
+  border: 2px solid var(--tile-border);
+  border-radius: 4px;
+  background: var(--tile-bg);
+  color: var(--text-color);
+}
+
+#word-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+  max-width: 240px;
+  width: 100%;
+  text-align: center;
+}
+
+#word-list li {
+  margin: 2px 0;
+}
+
+button#restart {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button#restart:hover {
+  opacity: 0.8;
+}
+
+@media (max-width: 600px) {
+  .grid {
+    grid-template-columns: repeat(4, 50px);
+    gap: 8px;
+  }
+  .tile {
+    width: 50px;
+    height: 50px;
+    font-size: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Implement 4x4 random letter grid with score, high score, timer and restart controls
- Add responsive styling, tile animations, light/dark theme and embedded audio feedback
- Provide full game logic with word validation, localStorage high score and theme support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916ccc4e54832fbfb22302afb481a1