### PR TITLE
Add Word Grid Challenge game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Word Grid Challenge</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1 class="title">Word Grid Challenge</h1>
+  <header class="controls">
+    <div class="scores">
+      <div>Score: <span id="score">0</span></div>
+      <div>High Score: <span id="high-score">0</span></div>
+      <div>Time: <span id="timer">60</span>s</div>
+    </div>
+    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+  </header>
+  <main>
+    <div id="grid" class="grid"></div>
+    <div class="input-area">
+      <input id="word-input" type="text" placeholder="Type a word" autocomplete="off" />
+      <button id="submit-word">Submit</button>
+    </div>
+    <ul id="word-list"></ul>
+    <button id="restart">Restart</button>
+  </main>
+  <audio id="success-sound" src="data:audio/wav;base64,UklGRpYDAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YXIDAAAAAAEQwh8EL4g9Fkt1V3Vi6Wusc555p323f8V/0n3meQ90ZmwKYx9Y0ktVPt0vpCDpEOkA5/Ag4dbRRcOotTapIZ6VlLmMrIaHglqALoAEgtSFj4sek2OcOKdys+DAS8963jDuLv4xDv0dUC3tO5pJHlZIYexq4XIJeUt9lH/efyV+cXrRdFxtL2RvWUhN6z+MMWcitxK8Arfy5uKK0+HEJrePqlCflZWGjUSH5oJ/gBmAtYFMhdCKLJJBm+ql/rFLv53Nudxi7Fv8YQw3HJsrTzoaSMJUFmDoaRBybnjofGx/739xfvZ6jXVLbk9lu1q6Tn5BOTMnJIQUjgSH9K3kQdWBxqi47auEoJyWWo7ih0yDq4ALgGyByoQYij+RI5qhpI6wur3xy/naluqI+pAKbhrjKa44lkZiU+Be32g6cc13f3w8f/p/tn50e0J2NW9pZgJcKVANQ+Q05iVQFmEGWfZ25vrWI8gtuk+tvqGnlzSPhoi4g96AA4AqgU+EZYlYkAuZXKMiry28SMo72crotvi/CKUYKCgKNw9F/lGkXdFnXXAldw98Bn/+f/R+7Hvydhpwf2dEXZJRmUSMNqMnHBgzCCr4QOi22MnJtru2rvyiuJgTkDGJK4QYgQKA74Dag7mIdo/5lx2iuq2iuqLIf9f/5uT27QbaFmwmYzWEQ5ZQY1y9ZntveHaZe8l+/H8tf158m3f4cI9ogV74UiFGMTheKeUZBQr8+Qzqc9pxy0O9ILA/pM+Z+ZDhiaWEWIEIgLqAbIMSiJuO65bioFesHLn+xsXVNuUT9RoFDhWuJLoz9kEpTx5bpGWSbsR1HHuGfvN/Xn/JfD540XGZabpfWVSmR9M5FyuuG9YLz/vY6zLcHM3Tvo+xh6XqmuSRmIokhZ6BFICMgASDcofFjeOVrJ/4qpm3XsUO1G7jQvNIA0ET7iINMmRAuE3TWYZkpG0KdZl6PH7jf4l/Ln3beKNynmrtYLZVJ0lyO80sdR2mDaL9pu3z3crOZsACs9SmC5zVklWLqoXrgSeAZICjgtmG9ozhlHuenakatsDDWNKo4XLxdQFzESshXjDPPkNMhFhiY7FsSnQQeux9zX+tf4x9cnlwc55rG2IPV6RKDT2BLjofdg90/3Tvtt960P3BebQlqDKdy5MYjDeGP4JAgEOASII=" preload="auto"></audio>
+    <audio id="fail-sound" src="data:audio/wav;base64,UklGRpYDAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YXIDAAAAAAIEBAgEDAEQ+hPuF9sbwh+hI3cnQysEL7kyYTb8OYg9BUFxRM1HFktMTm5RfFR1V1haJF3ZX3Vi+WRjZ7Rp6WsEbgNw5nGsc1V14XZOeJ55z3rhe9N8p31afu5+Y3+3f+t//n/yf8V/eH8Mf39+0n0GfRp8EHvmeZ14NneydQ90UHJzcHtuZmw3auxniGUKY3NgxF39Wh9YK1UiUgRP0kuNSDZFzkFVPsw6NDePM90vHixVKIEkpCC/HNMY4BTpEOwM7QjsBOkA5/zl+OT05/Dt7PjoCeUg4T/dZ9mZ1dbRHs5yytTGRcPEv1S89biotW2yRq8zrDapTqZ9o8OgIZ6XmyeZ0ZaVlHSSb5CFjrmMCYt3iQKIrIZ0hVuEYYOHgsyBMIG1gFqAHoADgAiALoBzgNmAXoEEgsmCrYOxhNSFFYd1iPOJj4tIjR6PEJEek0iVjJfrmWOc9J6eoWCkOKcnqiytRbBys7O2BrpqveDAZcT5x5zLS88H087WoNp63l7iSOY66jDuK/Iq9iv6Lv4wAjIGMwoxDiwSIhYTGv0d4CG6JYopUC0LMbk0WzjtO3E/5UJIRppJ2UwEUBxTHlYLWeFboV5IYddjTWaqaOxqE20ebw5x4XKYdDF2rHcJeUh6aHtpfEt9DX6vfjJ/lH/Xf/l/+3/ef59/QX/DfiV+Z32JfI17cXo2ed13ZnbRdB9zT3Fkb1xtOGv6aKFmL2SjYf9eQ1xvWYVWhlNxUEhNDEq9RlxD6z9pPNg4OTWMMdMtDyo/JmcihR6cGqwWtxK9Dr8Kvga8Arr+t/q29rfyu+7E6tLm5uIC3ybbU9eK083PHMx3yOHEWsHivXu6Jrfjs7Owl62Pqp2nwqT9oVCfu5w/mt2XlZVok1aRYI+GjcmLKoqoiESH/oXXhM+D5oIdgnOB6YB/gDWADIACgBmAUICngB6BtYFrgkGDN4RMhX+G0odCidCKfIxFjiqQLJJJlIGW1JhBm8edZaAco+qlz6jKq9qu/rE2tYG43rtLv8rCV8bzyZ3NU9EV1eLYudyY4IDkbuhi7FzwWfRZ+Fv8XQBgBGEIYQxeEFYUSRg3HB0g+yPQJ5srWy8PM7Y2TzraPVVBwEQaSGFLlk62UcJUuVeaWmRdFmCxYjJlmmfoaRxsNG4wcBBy1HN6dQN3bng=" preload="auto"></audio>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,124 @@
+const gridEl = document.getElementById('grid');
+const inputEl = document.getElementById('word-input');
+const scoreEl = document.getElementById('score');
+const highScoreEl = document.getElementById('high-score');
+const timerEl = document.getElementById('timer');
+const wordListEl = document.getElementById('word-list');
+const restartBtn = document.getElementById('restart');
+const submitBtn = document.getElementById('submit-word');
+const themeToggle = document.getElementById('theme-toggle');
+const successSound = document.getElementById('success-sound');
+const failSound = document.getElementById('fail-sound');
+
+let gridLetters = [];
+let usedWords = new Set();
+let score = 0;
+let timeLeft = 60;
+let timerId = null;
+let highScore = parseInt(localStorage.getItem('highScore')) || 0;
+highScoreEl.textContent = highScore;
+
+function generateGrid() {
+  gridEl.innerHTML = '';
+  gridLetters = [];
+  for (let i = 0; i < 16; i++) {
+    const letter = String.fromCharCode(65 + Math.floor(Math.random() * 26));
+    gridLetters.push(letter);
+    const tile = document.createElement('div');
+    tile.className = 'tile';
+    tile.textContent = letter;
+    gridEl.appendChild(tile);
+  }
+}
+
+function startGame() {
+  score = 0;
+  usedWords.clear();
+  wordListEl.innerHTML = '';
+  scoreEl.textContent = score;
+  inputEl.value = '';
+  inputEl.disabled = false;
+  submitBtn.disabled = false;
+  timeLeft = 60;
+  timerEl.textContent = timeLeft;
+  if (timerId) clearInterval(timerId);
+  timerId = setInterval(() => {
+    timeLeft--;
+    timerEl.textContent = timeLeft;
+    if (timeLeft <= 0) {
+      endGame();
+    }
+  }, 1000);
+  generateGrid();
+  inputEl.focus();
+}
+
+function endGame() {
+  clearInterval(timerId);
+  inputEl.disabled = true;
+  submitBtn.disabled = true;
+  const words = Array.from(usedWords);
+  alert(`Time's up!\nScore: ${score}\nWords: ${words.join(', ')}`);
+  if (score > highScore) {
+    highScore = score;
+    localStorage.setItem('highScore', highScore);
+    highScoreEl.textContent = highScore;
+  }
+}
+
+function validateWord(word) {
+  if (word.length < 3) return false;
+  if (usedWords.has(word)) return false;
+  const gridCounts = {};
+  gridLetters.forEach(l => (gridCounts[l] = (gridCounts[l] || 0) + 1));
+  const wordCounts = {};
+  for (const char of word) {
+    if (!gridCounts[char]) return false;
+    wordCounts[char] = (wordCounts[char] || 0) + 1;
+    if (wordCounts[char] > gridCounts[char]) return false;
+  }
+  return true;
+}
+
+function submitWord() {
+  const word = inputEl.value.trim().toUpperCase();
+  if (!word) return;
+  if (validateWord(word)) {
+    usedWords.add(word);
+    score += word.length;
+    scoreEl.textContent = score;
+    const li = document.createElement('li');
+    li.textContent = word;
+    wordListEl.appendChild(li);
+    successSound.currentTime = 0;
+    successSound.play();
+  } else {
+    failSound.currentTime = 0;
+    failSound.play();
+  }
+  inputEl.value = '';
+}
+
+inputEl.addEventListener('keydown', e => {
+  if (e.key === 'Enter') {
+    submitWord();
+  }
+});
+submitBtn.addEventListener('click', submitWord);
+restartBtn.addEventListener('click', startGame);
+
+function applyTheme(theme) {
+  document.body.classList.toggle('dark', theme === 'dark');
+  themeToggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+}
+
+const savedTheme = localStorage.getItem('theme') || 'light';
+applyTheme(savedTheme);
+
+themeToggle.addEventListener('click', () => {
+  const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+  localStorage.setItem('theme', newTheme);
+  applyTheme(newTheme);
+});
+
+window.addEventListener('load', startGame);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,162 @@
+:root {
+  --bg-color: #ffe4c4;
+  --text-color: #003366;
+  --tile-bg: #ffffff;
+  --tile-border: #cccccc;
+  --accent-color: #003366;
+  --accent-text: #ffe4c4;
+}
+
+body.dark {
+  --bg-color: #001a33;
+  --text-color: #e2e2e2;
+  --tile-bg: #333333;
+  --tile-border: #555555;
+}
+
+body {
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.title {
+  margin-top: 1rem;
+  font-size: 2.5rem;
+  background: var(--accent-color);
+  color: var(--accent-text);
+  padding: 0.25rem 0.75rem;
+  border-radius: 6px;
+}
+
+.controls {
+  width: 100%;
+  max-width: 500px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+}
+
+.scores {
+  display: flex;
+  gap: 1rem;
+}
+
+#theme-toggle {
+  padding: 0.5rem;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 60px);
+  gap: 10px;
+  margin-top: 1rem;
+}
+
+.tile {
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  background: var(--tile-bg);
+  border: 2px solid var(--tile-border);
+  border-radius: 8px;
+  transition: transform 0.2s ease, background 0.3s ease;
+  user-select: none;
+}
+
+.tile:hover {
+  transform: scale(1.1) rotate(2deg);
+  background: var(--accent-color);
+  color: #fff;
+}
+
+
+.input-area {
+  margin-top: 1rem;
+  display: flex;
+}
+
+#word-input {
+  padding: 0.5rem;
+  font-size: 1rem;
+  text-transform: uppercase;
+  border: 2px solid var(--tile-border);
+  border-radius: 4px;
+  background: var(--tile-bg);
+  color: var(--text-color);
+  box-sizing: border-box;
+}
+
+#submit-word {
+  margin-left: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: 2px solid var(--accent-color);
+  border-radius: 4px;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+#submit-word:hover {
+  opacity: 0.9;
+}
+
+#word-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+  max-width: 240px;
+  width: 100%;
+  text-align: center;
+}
+
+#word-list li {
+  margin: 2px 0;
+}
+
+button#restart {
+  margin-top: 1rem;
+}
+
+button#restart:hover {
+  opacity: 0.8;
+}
+
+@media (max-width: 600px) {
+  .grid {
+    grid-template-columns: repeat(4, 50px);
+    gap: 8px;
+  }
+  .tile {
+    width: 50px;
+    height: 50px;
+    font-size: 1.5rem;
+  }
+}
+
+button {
+  background: var(--accent-color);
+  color: var(--accent-text);
+  border: 2px solid var(--accent-color);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#word-input,
+#submit-word {
+  height: 2.5rem;
+}


### PR DESCRIPTION
## Summary
- Add vibrant Word Grid Challenge layout with scoreboard, timer, and interactive letter grid
- Implement game logic for word validation, scoring, and theme toggling, complete with embedded sounds
- Include in-page "Word Grid Challenge" heading and browser title
- Refine colors with dark-blue accents on titles and buttons against a pale background
- Fix audio embed to remove stray markup and equalize input/button sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916ccc4e54832fbfb22302afb481a1